### PR TITLE
[pypi] Add github action for pypi publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  pypi-publish:
+    name: upload release to PyPI
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+    
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+
+      - name: Setup pdm
+        uses: pdm-project/setup-pdm@v3
+        with:
+          python-version: "3.12"
+
+      - name: Build package
+        run: pdm build
+      
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,7 @@ authors = [
 maintainers = [
     {name = "Modular Inc", email = "hello@modular.com"}
 ]
-description = "Stacked PRs for GitHub"
-version = "1.0"
+description = "Stacked PRs for GitHub."
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.8"
@@ -23,7 +22,8 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",
 ]
-dependencies = []
+# Version is dynamically set by pdm by the SCM version
+dynamic = ["version"]
 
 [project.urls]
 Homepage = "https://github.com/modularml/stack-pr"
@@ -35,6 +35,8 @@ stack-pr = "stack_pr.cli:main"
 
 [tool.pdm]
 distribution = true
+source = "scm"
+fallback_version = "0.0.0"
 
 [tool.pixi.project]
 channels = ["conda-forge"]
@@ -42,6 +44,7 @@ platforms = ["osx-arm64", "osx-64", "linux-64", "linux-aarch64"]
 
 [tool.pixi.pypi-dependencies]
 stack-pr = { path = ".", editable = true }
+pdm = ">=2.17.1,<2.18"
 
 [tool.pixi.tasks]
 

--- a/src/stack_pr/__main__.py
+++ b/src/stack_pr/__main__.py
@@ -1,4 +1,4 @@
-from .stack_pr import main
+from .cli import main
 
 if __name__ == "__main__":
     main()

--- a/src/stack_pr/cli.py
+++ b/src/stack_pr/cli.py
@@ -1,10 +1,8 @@
-#!/usr/bin/env python3
-#
 # stack-pr: a tool for working with stacked PRs on github.
 #
-# ------------------
-# stack-pr.py submit
-# ------------------
+# ---------------
+# stack-pr submit
+# ---------------
 #
 # Semantics:
 #  1. Find merge-base (the most recent commit from 'main' in the current branch)
@@ -23,9 +21,9 @@
 # branch of each PR will be the head branch of the previous PR, or 'main' for
 # the first PR in the stack.
 #
-# ----------------
-# stack-pr.py land
-# ----------------
+# -------------
+# stack-pr land
+# -------------
 #
 # Semantics:
 #  1. Find merge-base (the most recent commit from 'main' in the current branch)
@@ -38,9 +36,9 @@
 # If 'land' succeeds, all the PRs from the stack will be merged into 'main',
 # all the corresponding remote and local branches deleted.
 #
-# -------------------
-# stack-pr.py abandon
-# -------------------
+# ----------------
+# stack-pr abandon
+# ----------------
 #
 # Semantics:
 # For all commits in the stack that have valid stack-info:


### PR DESCRIPTION
Add a github action that can be used to upload to pypi.

Make the version number dynamic so now the tag determines the version number of the package so we can use the github release system to cut releases. These should automatically get uploaded to pypi when we tag and release here.

Also add a file I missed in the last commit. 