### PR TITLE
fix relative imports and --target setting

### DIFF
--- a/src/stack_pr/__main__.py
+++ b/src/stack_pr/__main__.py
@@ -1,4 +1,4 @@
-from .cli import main
+from stack_pr.cli import main
 
 if __name__ == "__main__":
     main()

--- a/src/stack_pr/cli.py
+++ b/src/stack_pr/cli.py
@@ -53,14 +53,14 @@ import os
 import re
 from subprocess import SubprocessError
 
-from .git import (
+from stack_pr.git import (
     branch_exists,
     check_gh_installed,
     get_current_branch_name,
     get_gh_username,
     get_uncommitted_changes,
 )
-from .shell_commands import get_command_output, run_shell_command
+from stack_pr.shell_commands import get_command_output, run_shell_command
 from typing import List, NamedTuple, Optional, Pattern
 
 # A bunch of regexps for parsing commit messages and PR descriptions
@@ -743,7 +743,7 @@ def deduce_base(args: CommonArgs) -> CommonArgs:
     if args.base:
         return args
     deduced_base = get_command_output(
-        ["git", "merge-base", args.head, f"{args.remote}/main"]
+        ["git", "merge-base", args.head, f"{args.remote}/{args.target}"]
     )
     return CommonArgs(deduced_base, args.head, args.remote, args.target)
 


### PR DESCRIPTION
Issue 1:

--target bug, "/main" was hardcoded

Issue 2:

Relative imports are hard to work with. E.g.

~/stack_pr

~/my_repo

In my repo, I can not python -m call into ~/stack_pr, because I can not go up in the directory hierarhy, I think.

So my approach is:

1. remove relative imports
2. add src root into PYTHONPATH

then within ~/my_repo I can do

> python /home/salex/stack-pr/src/stack_pr/cli.py submit --target my_base