### PR TITLE
Suppress subcommand output by default

### DIFF
--- a/src/stack_pr/shell_commands.py
+++ b/src/stack_pr/shell_commands.py
@@ -6,7 +6,7 @@ ShellCommand = Iterable[Union[str, Path]]
 
 
 def run_shell_command(
-    cmd: ShellCommand, *, check: bool = True, **kwargs: Any
+        cmd: ShellCommand, *, quiet: bool, check: bool = True, **kwargs: Any
 ) -> subprocess.CompletedProcess:
     """Runs a shell command using the arguments provided.
 
@@ -26,6 +26,8 @@ def run_shell_command(
         raise ValueError("shell support has been removed")
     _ = subprocess.list2cmdline(cmd)
     kwargs.update({"check": check})
+    if quiet:
+        kwargs.update({"stdout": subprocess.DEVNULL, "stderr": subprocess.DEVNULL})
     return subprocess.run(list(map(str, cmd)), **kwargs)
 
 
@@ -45,5 +47,5 @@ def get_command_output(cmd: ShellCommand, **kwargs: Any) -> str:
     """
     if "capture_output" in kwargs:
         raise ValueError("Cannot pass capture_output when using get_command_output")
-    proc = run_shell_command(cmd, capture_output=True, **kwargs)
+    proc = run_shell_command(cmd, capture_output=True, quiet=False, **kwargs)
     return proc.stdout.decode("utf-8").rstrip()


### PR DESCRIPTION
For large or busy repositories, stack-pr commands can generate hundreds
of lines of output from Git subcommands being executed. Most of the time
these don't matter; the user doesn't care about them. This PR suppresses
them by default by redirecting stdout and stderr to
`subprocess.DEVNULL`. If this output is desired in a specific case, the
command-line flag `--verbose` (`-V`) can be used to avoid this
redirection.
