### PR TITLE
Fix delete_remote_branches

### DIFF
--- a/src/stack_pr/cli.py
+++ b/src/stack_pr/cli.py
@@ -967,7 +967,7 @@ def delete_remote_branches(st: List[StackEntry], remote: str):
             "git",
             "for-each-ref",
             f"refs/remotes/{remote}/{username}/stack",
-            "--format='%(refname)'",
+            "--format=%(refname)",
         ]
     ).split()
     refs = [x.replace(f"refs/remotes/{remote}/", "") for x in refs]


### PR DESCRIPTION
delete_remote_branches formatted remote
branch refs with an extra single quote
around each branch. These would never
match the branch strings stored in
stack entries, so remote branches would
never get deleted. This commit removes
the extra single quotes.