### PR TITLE
Don't attempt to delete remote branch after a PR has landed.

### DIFF
--- a/src/stack_pr/cli.py
+++ b/src/stack_pr/cli.py
@@ -1117,9 +1117,6 @@ def command_land(args: CommonArgs):
     )
 
     delete_local_branches(st, args.verbose)
-    delete_remote_branches(
-        st[:1], args.remote, args.verbose, args.branch_name_template
-    )
 
     # If local branch {target} exists, rebase it on the remote/target
     if branch_exists(args.target):


### PR DESCRIPTION
Stacked PRs:
 * __->__#42


--- --- ---

### Don't attempt to delete remote branch after a PR has landed.


GitHub deletes the remote branch automatically when the PR is merged, so
we don't to explicitly do that. Trying to delete it currently results in
an error like this:
```
error: unable to delete 'ZolotukhinM/stack/1': remote ref does not exist
error: failed to push some refs to '...'
```
The code for deleting the branch has been sitting there for a long time,
but until a fix in #27 it used incorrect branch names.