### PR TITLE
Allow merge state to be UNKNOWN

### DIFF
--- a/src/stack_pr/cli.py
+++ b/src/stack_pr/cli.py
@@ -506,7 +506,7 @@ def verify(st: List[StackEntry], check_base: bool = False):
             raise RuntimeError
 
         # The first entry on the stack needs to be actually mergeable on GitHub.
-        if check_base and index == 0 and d["mergeStateStatus"] != "CLEAN":
+        if check_base and index == 0 and d["mergeStateStatus"] != "CLEAN" and d["mergeStateStatus"] != "UNKNOWN":
             error(ERROR_STACKINFO_PR_NOT_MERGEABLE.format(**locals()))
             raise RuntimeError
 


### PR DESCRIPTION
Stacked PRs:
 * __->__#49


--- --- ---

### Allow merge state to be UNKNOWN


When validating whether a PR is mergeable on GitHub, sometimes the PR
will get stuck in an `UNKNOWN` merge state and block merging, even if
it's mergeable in the GitHub UI.